### PR TITLE
Add product information when selecting single order

### DIFF
--- a/controllers/orders-ctrl.js
+++ b/controllers/orders-ctrl.js
@@ -15,7 +15,6 @@ module.exports.getOneOrder = ({params: {orderId}}, res, next) => {
     .then( arrayProducts => {
       let joinedOrderProducts = { order };
       joinedOrderProducts.order.products = arrayProducts
-      
       res.status(200).json(joinedOrderProducts)
     })
   )

--- a/controllers/orders-ctrl.js
+++ b/controllers/orders-ctrl.js
@@ -1,4 +1,4 @@
-const { getAllOrders, getSingleOrder, deleteOrder, addSingleOrder, editOrder } = require('../models/Order');
+const { getAllOrders, getSingleOrder, deleteOrder, addSingleOrder, editOrder, getOrdersProducts } = require('../models/Order');
 
 module.exports.getOrders = (req, res, next) => {
   getAllOrders()
@@ -10,9 +10,15 @@ module.exports.getOrders = (req, res, next) => {
 
 module.exports.getOneOrder = ({params: {orderId}}, res, next) => {
   getSingleOrder(orderId)
-  .then( order => {
-    res.status(200).json(order)
-  })
+  .then( order => 
+    getOrdersProducts(orderId)
+    .then( arrayProducts => {
+      let joinedOrderProducts = { order };
+      joinedOrderProducts.order.products = arrayProducts
+      
+      res.status(200).json(joinedOrderProducts)
+    })
+  )
   .catch ( err => next(err));
 };
 

--- a/data/orders.json
+++ b/data/orders.json
@@ -1,112 +1,104 @@
 {
   "orders": [
     {
-      "order_date": "2017-7-15",
-      "payment_type_id": null
-    },
-    {
-      "order_date": "2017-3-29",
-      "payment_type_id": null
-    },
-    {
+      "customer_id": 20,
       "order_date": "2017-5-23",
       "payment_type_id": null
     },
     {
-      "order_date": "2017-5-22",
+      "customer_id": 3,
+      "order_date": "2017-7-28",
       "payment_type_id": null
     },
     {
-      "order_date": "2017-12-9",
+      "customer_id": 6,
+      "order_date": "2017-11-10",
       "payment_type_id": null
     },
     {
-      "order_date": "2017-11-14",
+      "customer_id": 10,
+      "order_date": "2018-3-9",
       "payment_type_id": null
     },
     {
-      "order_date": "2017-6-27",
+      "customer_id": 8,
+      "order_date": "2017-9-22",
       "payment_type_id": null
     },
     {
-      "order_date": "2018-2-2",
+      "customer_id": 1,
+      "order_date": "2017-10-7",
       "payment_type_id": null
     },
     {
-      "order_date": "2017-12-14",
+      "customer_id": 4,
+      "order_date": "2017-9-19",
       "payment_type_id": null
     },
     {
-      "order_date": "2017-5-22",
+      "customer_id": 17,
+      "order_date": "2017-5-23",
       "payment_type_id": null
     },
     {
-      "order_date": "2017-6-14",
+      "customer_id": 8,
+      "order_date": "2017-8-16",
       "payment_type_id": null
     },
     {
-      "order_date": "2017-4-10",
+      "customer_id": 5,
+      "order_date": "2017-5-13",
       "payment_type_id": null
     },
     {
-      "order_date": "2018-3-1",
+      "customer_id": 9,
+      "order_date": "2017-4-4",
       "payment_type_id": null
     },
     {
-      "order_date": "2018-2-1",
+      "customer_id": 3,
+      "order_date": "2017-7-14",
       "payment_type_id": null
     },
     {
-      "order_date": "2017-5-28",
+      "customer_id": 10,
+      "order_date": "2017-4-19",
       "payment_type_id": null
     },
     {
-      "order_date": "2017-12-6",
+      "customer_id": 8,
+      "order_date": "2018-2-12",
       "payment_type_id": null
     },
     {
-      "order_date": "2017-5-28",
+      "customer_id": 10,
+      "order_date": "2018-2-14",
       "payment_type_id": null
     },
     {
-      "order_date": "2017-10-10",
-      "payment_type_id": 5
+      "customer_id": 6,
+      "order_date": "2017-6-30",
+      "payment_type_id": null
     },
     {
-      "order_date": "2017-10-9",
-      "payment_type_id": 4
+      "customer_id": 6,
+      "order_date": "2018-3-18",
+      "payment_type_id": null
     },
     {
-      "order_date": "2017-12-20",
-      "payment_type_id": 19
+      "customer_id": 2,
+      "order_date": "2018-3-5",
+      "payment_type_id": null
     },
     {
-      "order_date": "2017-12-20",
-      "payment_type_id": 17
+      "customer_id": 15,
+      "order_date": "2017-5-6",
+      "payment_type_id": null
     },
     {
-      "order_date": "2017-12-20",
-      "payment_type_id": 17
-    },
-    {
-      "order_date": "2017-12-20",
-      "payment_type_id": 17
-    },
-    {
-      "order_date": "2017-12-20",
-      "payment_type_id": 1
-    },
-    {
-      "order_date": "2017-12-20",
-      "payment_type_id": 1
-    },
-    {
-      "order_date": "2017-12-20",
-      "payment_type_id": 2
-    },
-    {
-      "order_date": "2017-12-20",
-      "payment_type_id": 2
+      "customer_id": 10,
+      "order_date": "2017-4-26",
+      "payment_type_id": null
     }
   ]
 }

--- a/databases/orders.js
+++ b/databases/orders.js
@@ -12,14 +12,15 @@ module.exports.buildOrderTable = () => {
     
     db.run(`CREATE TABLE IF NOT EXISTS orders (
       order_id INTEGER PRIMARY KEY,
+      customer_id INTEGER,
       order_date TEXT NOT NULL,
       payment_type_id INTEGER,
-      FOREIGN KEY (payment_type_id) REFERENCES payment_types(payment_type_id))`
-    );
+      FOREIGN KEY (payment_type_id) REFERENCES payment_types(payment_type_id),
+      FOREIGN KEY (customer_id) REFERENCES customers(customer_id))`);
 
-    orders.forEach( ({order_date, payment_type_id, create_date}) => {
-      db.run(`INSERT INTO orders (order_date, payment_type_id)
-              VALUES ("${order_date}", ${payment_type_id})`, (err) => {
+    orders.forEach( ({customer_id, order_date, payment_type_id, create_date}) => {
+      db.run(`INSERT INTO orders (customer_id, order_date, payment_type_id)
+              VALUES ("${customer_id}","${order_date}", ${payment_type_id})`, (err) => {
                 if(err) return err;
               });
     });

--- a/generators/order-faker.js
+++ b/generators/order-faker.js
@@ -8,7 +8,8 @@ const generateOrders = () => {
 
   for (let i = 0; i < 20; i ++) {
     let orderDate = faker.date.past();
-    orders.push({"order_date": orderDate.toLocaleDateString(), "payment_type_id": null});
+    let custId = faker.random.number({ min: 1, max: 20 });
+    orders.push({"customer_id": custId,"order_date": orderDate.toLocaleDateString(), "payment_type_id": null});
   }
 
   return { orders };

--- a/models/Order.js
+++ b/models/Order.js
@@ -54,3 +54,16 @@ module.exports.deleteOrder = orderID => {
     });
   });
 };
+
+module.exports.getOrdersProducts = orderID => {
+  return new Promise ((resolve, reject) => {
+    db.all(`SELECT  products.*
+    FROM orders, products, orders_products
+    WHERE orders.order_id = orders_products.order_id
+    AND products.product_id = orders_products.product_id
+    AND orders.order_id = ${orderID}`, (err, ordersJoined) => {
+      if (err) return reject(err);
+      resolve(ordersJoined);
+    });
+  });
+};


### PR DESCRIPTION
Changes:
dev receives an array of products containing all product information when a single order is queried

To Test:
```run nodemon app.js```

In browser:
```localhost:8080/api/orders/(1-20)```

Expected results:
```
order {
  ...
  products: [
    ...
  ]
}
```

Resolves issues #10 

And I also added customer ID to order

Expected results :
``` correct ERD and tables```