### PR TITLE
Mb customer query fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,7 +274,7 @@ Example:
 * GET all customers that are active by running Get `http://localhost:8080/api/customers/?active=true`
 * GET all customers that are not active by running Get `http://localhost:8080/api/customers/?active=false` 
 * PUT You can update the info on a specific customer by running a Put call to `http://localhost:8080/api/customers/`
-        *You must Put the entire changed object, which will include the below:
+        *You must Put the entire changed object, which will include the below (note - unable to change customer_id):
 ```
     {
       "customer_id": INT,
@@ -282,15 +282,35 @@ Example:
       "last_name": "TEXT",
       "join_date": "2018-03-05"
     }
+    
 
 ```
+
+  example:
+  ```
+      {
+      "customer_id": 1,
+      "first_name": "Billy",
+      "last_name": "Bob",
+      "join_date": "2018-03-28"
+    }
+  ```
+
 * POST To add a new customer, post to `http://localhost:8080/api/customers`.
         *To add a new customer,the below is required:
  ```
     {
       "first_name": "TEXT",
       "last_name": "TEXT",
-      "create_date": "2018-03-05"
+      "join_date": "DATE"
+    }
+```
+  example:
+```
+    {
+      "first_name": "Joe",
+      "last_name": "Shepherd",
+      "join_date": "03/30/2018"
     }
 ```
 
@@ -302,13 +322,12 @@ Example:
       "value": "NEWVALUE"
     }
 ```
-* POST To add a new customer, post to `http://localhost:8080/api/customers`.
-        *To add a new customer,the below is required:
- ```
+
+  example:
+```
     {
-      "first_name": "TEXT",
-      "last_name": "TEXT",
-      "create_date": "2018-03-05"
+      "column": "first_name",
+      "value": "Bill III"
     }
 ```
 

--- a/README.md
+++ b/README.md
@@ -280,8 +280,7 @@ Example:
       "customer_id": INT,
       "first_name": "TEXT",
       "last_name": "TEXT",
-      "join_date": "2018-03-05",
-      "active": INT (0 or 1)
+      "join_date": "2018-03-05"
     }
 
 ```
@@ -291,8 +290,7 @@ Example:
     {
       "first_name": "TEXT",
       "last_name": "TEXT",
-      "create_date": "2018-03-05",
-      "active": INT (0 or 1)
+      "create_date": "2018-03-05"
     }
 ```
 
@@ -310,9 +308,7 @@ Example:
     {
       "first_name": "TEXT",
       "last_name": "TEXT",
-      "create_date": "2018-03-05",
-      "active": INT (0 or 1)
-
+      "create_date": "2018-03-05"
     }
 ```
 

--- a/data/customers.json
+++ b/data/customers.json
@@ -1,232 +1,104 @@
 {
   "customers": [
     {
-      "first_name": "Annabelle",
-      "last_name": "Carter",
-      "create_date": "2016-11-14",
-      "active": 0
+      "first_name": "Hortense",
+      "last_name": "Lemke",
+      "create_date": "2016-09-30"
     },
     {
-      "first_name": "Beau",
-      "last_name": "Block",
-      "create_date": "2018-03-05",
-      "active": 0
+      "first_name": "Merlin",
+      "last_name": "Wuckert",
+      "create_date": "2010-04-28"
     },
     {
-      "first_name": "Torrance",
-      "last_name": "Kutch",
-      "create_date": "2010-08-16",
-      "active": 0
+      "first_name": "Katherine",
+      "last_name": "Legros",
+      "create_date": "2014-06-03"
     },
     {
-      "first_name": "Wendy",
-      "last_name": "Gerlach",
-      "create_date": "2015-12-12",
-      "active": 0
+      "first_name": "Eveline",
+      "last_name": "Nitzsche",
+      "create_date": "2014-09-03"
     },
     {
-      "first_name": "Sadie",
-      "last_name": "Feil",
-      "create_date": "2015-05-04",
-      "active": 0
+      "first_name": "Frank",
+      "last_name": "Toy",
+      "create_date": "2013-02-28"
     },
     {
-      "first_name": "Isaias",
-      "last_name": "Wolff",
-      "create_date": "2011-01-03",
-      "active": 0
+      "first_name": "Hilbert",
+      "last_name": "Muller",
+      "create_date": "2017-03-23"
     },
     {
-      "first_name": "Palma",
-      "last_name": "Emmerich",
-      "create_date": "2015-01-01",
-      "active": 0
+      "first_name": "Bennie",
+      "last_name": "Dickinson",
+      "create_date": "2012-01-11"
     },
     {
-      "first_name": "Brook",
-      "last_name": "Bernier",
-      "create_date": "2013-10-20",
-      "active": 0
+      "first_name": "Brielle",
+      "last_name": "Kovacek",
+      "create_date": "2015-07-27"
     },
     {
-      "first_name": "Ricardo",
-      "last_name": "Hintz",
-      "create_date": "2016-05-29",
-      "active": 0
+      "first_name": "Jarrod",
+      "last_name": "Thiel",
+      "create_date": "2009-07-04"
     },
     {
-      "first_name": "Terrance",
-      "last_name": "Collins",
-      "create_date": "2012-09-14",
-      "active": 0
+      "first_name": "Kenya",
+      "last_name": "Collier",
+      "create_date": "2010-04-29"
     },
     {
-      "first_name": "Mozelle",
-      "last_name": "Orn",
-      "create_date": "2014-03-07",
-      "active": 0
+      "first_name": "Armando",
+      "last_name": "Bechtelar",
+      "create_date": "2010-08-15"
     },
     {
-      "first_name": "Tatyana",
-      "last_name": "Lubowitz",
-      "create_date": "2009-06-28",
-      "active": 0
+      "first_name": "Oran",
+      "last_name": "Frami",
+      "create_date": "2016-02-20"
+    },
+    {
+      "first_name": "Karli",
+      "last_name": "McGlynn",
+      "create_date": "2011-07-12"
+    },
+    {
+      "first_name": "Leo",
+      "last_name": "Rowe",
+      "create_date": "2008-06-07"
+    },
+    {
+      "first_name": "Lonie",
+      "last_name": "Langosh",
+      "create_date": "2014-10-07"
+    },
+    {
+      "first_name": "Karlie",
+      "last_name": "Runolfsdottir",
+      "create_date": "2016-03-07"
+    },
+    {
+      "first_name": "Lucas",
+      "last_name": "Barrows",
+      "create_date": "2015-04-24"
+    },
+    {
+      "first_name": "Jordon",
+      "last_name": "Barrows",
+      "create_date": "2014-04-17"
+    },
+    {
+      "first_name": "Charity",
+      "last_name": "Mann",
+      "create_date": "2016-09-16"
     },
     {
       "first_name": "Lon",
-      "last_name": "Sipes",
-      "create_date": "2013-06-05",
-      "active": 0
-    },
-    {
-      "first_name": "Fleta",
-      "last_name": "Considine",
-      "create_date": "2008-08-06",
-      "active": 0
-    },
-    {
-      "first_name": "Lilla",
-      "last_name": "Wisoky",
-      "create_date": "2017-04-24",
-      "active": 0
-    },
-    {
-      "first_name": "Leonie",
-      "last_name": "Dooley",
-      "create_date": "2017-12-20",
-      "active": 0
-    },
-    {
-      "first_name": "Santa",
-      "last_name": "Tillman",
-      "create_date": "2009-01-29",
-      "active": 0
-    },
-    {
-      "first_name": "Claudie",
-      "last_name": "Dare",
-      "create_date": "2017-02-26",
-      "active": 0
-    },
-    {
-      "first_name": "Keely",
-      "last_name": "Homenick",
-      "create_date": "2012-09-17",
-      "active": 0
-    },
-    {
-      "first_name": "Bonita",
-      "last_name": "Gleichner",
-      "create_date": "2011-07-22",
-      "active": 0
-    },
-    {
-      "first_name": "Cristina",
-      "last_name": "Rippin",
-      "create_date": "2009-07-01",
-      "active": 0
-    },
-    {
-      "first_name": "Mylene",
-      "last_name": "Orn",
-      "create_date": "2012-09-29",
-      "active": 0
-    },
-    {
-      "first_name": "Margie",
-      "last_name": "Oberbrunner",
-      "create_date": "2013-05-04",
-      "active": 0
-    },
-    {
-      "first_name": "Granville",
-      "last_name": "Bechtelar",
-      "create_date": "2010-08-31",
-      "active": 0
-    },
-    {
-      "first_name": "Torey",
-      "last_name": "O'Kon",
-      "create_date": "2013-04-07",
-      "active": 0
-    },
-    {
-      "first_name": "Maurice",
-      "last_name": "Mueller",
-      "create_date": "2016-08-01",
-      "active": 0
-    },
-    {
-      "first_name": "Jeff",
-      "last_name": "Nikolaus",
-      "create_date": "2010-12-23",
-      "active": 0
-    },
-    {
-      "first_name": "Burley",
-      "last_name": "Schimmel",
-      "create_date": "2017-08-04",
-      "active": 0
-    },
-    {
-      "first_name": "Halie",
-      "last_name": "Denesik",
-      "create_date": "2008-04-04",
-      "active": 0
-    },
-    {
-      "first_name": "Makayla",
-      "last_name": "Hand",
-      "create_date": "2012-06-29",
-      "active": 0
-    },
-    {
-      "first_name": "Leila",
-      "last_name": "McKenzie",
-      "create_date": "2016-07-14",
-      "active": 0
-    },
-    {
-      "first_name": "Filiberto",
-      "last_name": "Durgan",
-      "create_date": "2017-06-03",
-      "active": 0
-    },
-    {
-      "first_name": "Vernie",
-      "last_name": "Wunsch",
-      "create_date": "2012-03-20",
-      "active": 0
-    },
-    {
-      "first_name": "Jada",
-      "last_name": "Smith",
-      "create_date": "2016-12-30",
-      "active": 0
-    },
-    {
-      "first_name": "Alycia",
-      "last_name": "Harris",
-      "create_date": "2010-09-05",
-      "active": 0
-    },
-    {
-      "first_name": "Raymundo",
-      "last_name": "Larson",
-      "create_date": "2017-02-01",
-      "active": 0
-    },
-    {
-      "first_name": "Clarissa",
-      "last_name": "Wisoky",
-      "create_date": "2012-06-22",
-      "active": 0
-    },
-    {
-      "first_name": "Jazmyn",
-      "last_name": "Weissnat",
-      "create_date": "2012-09-19",
-      "active": 0
+      "last_name": "Crist",
+      "create_date": "2017-11-06"
     }
   ]
 }

--- a/databases/customers.js
+++ b/databases/customers.js
@@ -12,13 +12,12 @@ module.exports.buildCustomerTable = () => {
       customer_id INTEGER PRIMARY KEY,
       first_name TEXT NOT NULL,
       last_name TEXT NOT NULL,
-      join_date TEXT NOT NULL,
-      active INTEGER)`
+      join_date TEXT NOT NULL)`
     );
 
-    customers.forEach(({ first_name, last_name, create_date, active}) => {
+    customers.forEach(({ first_name, last_name, create_date}) => {
       db.run(`INSERT INTO customers
-              VALUES (null, "${first_name}", "${last_name}", "${create_date}", ${active})`, (err) => {
+              VALUES (null, "${first_name}", "${last_name}", "${create_date}")`, (err) => {
                 if(err) return err;
               });
     });

--- a/generators/customer-faker.js
+++ b/generators/customer-faker.js
@@ -14,8 +14,7 @@ const generateCustomers = () => {
     customers.push({
       first_name,
       last_name,
-      create_date,
-      active
+      create_date
     });
   }
     return { customers };

--- a/models/Customer.js
+++ b/models/Customer.js
@@ -13,9 +13,14 @@ module.exports.getAllCustomers = () => {
 };
 
 module.exports.getCustsByActivity = (status) => {
-  const statusQuery = (status === "true") ? 1 : 0; 
+  const condition = (status === "true") ? " > 0" : " = 0"; 
   return new Promise( (resolve, reject) => {
-    db.all(`SELECT * FROM customers WHERE active="${statusQuery}"`, (err, customer) => {
+    db.all(
+    `SELECT customers.*, COUNT(orders.customer_id) AS TotalOrders
+    FROM customers
+    LEFT JOIN orders ON orders.customer_id = customers.customer_id
+    GROUP BY customers.customer_id
+    HAVING TotalOrders ${condition}`, (err, customer) => {
       if (err) reject (err);
       resolve(customer);
     });

--- a/models/Customer.js
+++ b/models/Customer.js
@@ -63,7 +63,6 @@ module.exports.putCustomerObj = ({ customer_id, first_name, last_name, join_date
 
 module.exports.patchCustomerObj = (custID, { column, value }) => {
   return new Promise((resolve, reject) => {
-    // update table set column where id = param id
       db.run(`UPDATE customers SET ${column} = "${value}"
       WHERE customer_id = ${custID}
       `, function (err) {

--- a/models/Customer.js
+++ b/models/Customer.js
@@ -36,10 +36,10 @@ module.exports.getCustomer = (custID) => {
   });
 };
 
-module.exports.addCustomer = ({ first_name, last_name, join_date, active }) => {
+module.exports.addCustomer = ({ first_name, last_name, join_date }) => {
   return new Promise( (resolve, reject) => {
     db.run(`INSERT INTO customers 
-    VALUES(null, "${first_name}", "${last_name}", "${join_date}", "${active}" )`, function(err, computer) {
+    VALUES(null, "${first_name}", "${last_name}", "${join_date}" )`, function(err, computer) {
       if (err) return reject(err);
       resolve({ id : this.lastID });
       }
@@ -47,13 +47,12 @@ module.exports.addCustomer = ({ first_name, last_name, join_date, active }) => {
   });
 };
 
-module.exports.putCustomerObj = ({ customer_id, first_name, last_name, join_date, active }) => {
+module.exports.putCustomerObj = ({ customer_id, first_name, last_name, join_date }) => {
   return new Promise( (resolve, reject) => {
     db.run(`UPDATE customers SET
     first_name="${first_name}",
     last_name="${last_name}",
-    join_date="${join_date}",
-    active="${active}"
+    join_date="${join_date}"
     WHERE customer_id = ${customer_id}`, function(err) {
       if (err) return reject(err);
       resolve({ id : this.changes });


### PR DESCRIPTION
## Changes:
-Customer query is now updated to filter by customers with orders/without orders
-active boolean attribute removed from data creation and table creation
-readme updated with new requirements for put post patch

## To Test:
1. Start by running ```npm run build-tables``` to rebuild tables with new customer data, check DB to ensure customer table no longer includes active attribute
![image](https://user-images.githubusercontent.com/33636906/38140278-b7048b98-33f8-11e8-9deb-7e392c9b602e.png)

2. Run node app.js

3.In browser: `http://localhost:8080/api/customers/?active=true` should return only active customers. You can ensure this is true by reviewing the TotalOrders column created with this query - all returned customers should have >0 orders

3.In browser: `http://localhost:8080/api/customers/?active=false` should return only active customers. You can ensure this is true by reviewing the TotalOrders column created with this query - all returned customers should have 0 orders

4. In postman:
* PUT `http://localhost:8080/api/customers/`
      {
      "customer_id": 1,
      "first_name": "Billy",
      "last_name": "Bob",
      "join_date": "2018-03-28"
    }
  ```

* POST  `http://localhost:8080/api/customers`.
 
```
    {
      "first_name": "Joe",
      "last_name": "Shepherd",
      "join_date": "03/30/2018"
    }
```

* PATCH `http://localhost:8080/api/customers/1`.

```
    {
      "column": "first_name",
      "value": "Bill III"
    }
```

## Justification: 
This meets the requirements for ticket #11 where query should actually get customers with no orders/with orders.
